### PR TITLE
stream: improve Writable.destroy performance

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -45,6 +45,7 @@ const {
   getHighWaterMark,
   getDefaultHighWaterMark
 } = require('internal/streams/state');
+const assert = require('internal/assert');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_METHOD_NOT_IMPLEMENTED,
@@ -826,9 +827,16 @@ ObjectDefineProperties(Writable.prototype, {
 const destroy = destroyImpl.destroy;
 Writable.prototype.destroy = function(err, cb) {
   const state = this._writableState;
-  if (!state.destroyed) {
+
+  // Invoke pending callbacks.
+  if (
+    state.bufferedIndex < state.buffered.length ||
+    state[kOnFinished].length
+  ) {
+    assert(!state.destroyed);
     process.nextTick(errorBuffer, state);
   }
+
   destroy.call(this, err, cb);
   return this;
 };


### PR DESCRIPTION
Avoid nextTick if there are no pending callbacks.

PR-URL: https://github.com/nodejs/node/pull/35067
Reviewed-By: Matteo Collina <matteo.collina@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Ricky Zhou <0x19951125@gmail.com>

<!--This is a practice pull request for GA Software Engineering Immersive! (Sorry for inconvenience of not useful pull request -- hopefully in future with more skill will actually be able to contribute!
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
